### PR TITLE
Update the code snippet to prevent loading the SDK script more than once

### DIFF
--- a/public/embed-application.js
+++ b/public/embed-application.js
@@ -77,11 +77,14 @@ const visierConfig = {
     w[v] = w[v] || function() {
         (w[v].q = w[v].q || []).push(arguments)
     };
-    e = d.createElement(t);
-    x = d.getElementsByTagName(t)[0];
-    e.async = true;
-    e.src = c.visierUrl ? c.visierUrl + s : (c.loginUrl ? c.loginUrl.split("/auth/embedded")[0] + s : s);
-    x.parentNode.insertBefore(e, x)
+    if (!d.getElementById(s)) {
+        e = d.createElement(t);
+        x = d.getElementsByTagName(t)[0];
+        e.id = s;
+        e.async = true;
+        e.src = c.visierUrl ? c.visierUrl + s : (c.loginUrl ? c.loginUrl.split("/auth/embedded")[0] + s : s);
+        x.parentNode.insertBefore(e, x);
+    }
 })(window, document, 'script', '/assets/embedded/webAssets/sdk.v2.js', visierConfig, 'visier');
 
 // Bootstrap must always be the first call to `visier()`.

--- a/public/embed-chart.html
+++ b/public/embed-chart.html
@@ -110,11 +110,14 @@
             w[v] = w[v] || function() {
                 (w[v].q = w[v].q || []).push(arguments)
             };
-            e = d.createElement(t);
-            x = d.getElementsByTagName(t)[0];
-            e.async = true;
-            e.src = c.visierUrl ? c.visierUrl + s : (c.loginUrl ? c.loginUrl.split("/auth/embedded")[0] + s : s);
-            x.parentNode.insertBefore(e, x)
+            if (!d.getElementById(s)) {
+                e = d.createElement(t);
+                x = d.getElementsByTagName(t)[0];
+                e.id = s;
+                e.async = true;
+                e.src = c.visierUrl ? c.visierUrl + s : (c.loginUrl ? c.loginUrl.split("/auth/embedded")[0] + s : s);
+                x.parentNode.insertBefore(e, x);
+            }
         })(window, document, 'script', '/assets/embedded/webAssets/sdk.v2.js', visierConfig, 'visier');
 
         // Bootstrap must always be the first call to `visier()`.


### PR DESCRIPTION
The SDK is meant to be a singleton and should only be loaded once per page. To guard against, updating the script to check if the script was already added previously. If it exists, skip adding it again.